### PR TITLE
Reduce number of characters in stack

### DIFF
--- a/stages/director-gui/templates/hub.yml
+++ b/stages/director-gui/templates/hub.yml
@@ -4,11 +4,11 @@ Parameters:
   
   ClusterName:
     Type: String
-    Default: 'selenium-grid-rancher-ci-release'
+    Default: 'grid-rancher-ci-release'
     Description: Cluster name.
   LogName:
     Type: String
-    Default: 'selenium-grid-rancher-ecs-ci-release'
+    Default: 'grid-rancher-ecs-ci-release'
     Description: Cluster name.
   ContainerCpu:
     Type: Number
@@ -106,7 +106,7 @@ Resources:
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-      Name: !Join ['-', [!Ref 'AWS::StackName', 'drop-1']]
+      Name: !Ref 'AWS::StackName'
       Port: 4444
       Protocol: HTTP
       UnhealthyThresholdCount: 2


### PR DESCRIPTION
We need to limit number of characters in resource names, in order to fix this error:
Target group name 'grid-oep-e2e-rancher-10174-drop-1' cannot be longer than '32' characters (Service: AmazonElasticLoadBalancingV2; Status Code: 400; Error Code: ValidationError; Request ID: d87bf779-aef6-4834-b22a-8d5e321c36e3)