### PR TITLE
refactor(Script): Modified the sed command to remove cri env as containerd

### DIFF
--- a/stages/chaos/cstor-App-pod-kill/app-kill
+++ b/stages/chaos/cstor-App-pod-kill/app-kill
@@ -132,7 +132,6 @@ cd e2e-tests
 cp experiments/chaos/app_pod_failure/run_litmus_test.yml appkill.yml
 
 sed -i -e 's/app=jenkins-app/app=app-kill/g' \
--e 's/value: docker/value: containerd/g' \
 -e 's/name: app-failure/name: app-kill/g' \
 -e 's/value: app-jenkins-ns/value: app-kill/g' appkill.yml
 


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>
- Previously it was taking cri as containerd but we need docker so remvoed the sed command for changing cri to containerd. by default in the runner script it is docker