### PR TITLE
Add openebs install tests on cluster3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,6 +106,42 @@ TCID-DIR-OP-INSTALL-OPENEBS:
     - chmod 755 ./stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS
     - ./stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS
 
+TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE
+    - ./stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE
+
+TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE
+    - ./stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE
+
+TCID-DIR-OP-RE-INSTALL-OPENEBS:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-RE-INSTALL-OPENEBS
+    - ./stages/openebs-install/TCID-DIR-OP-RE-INSTALL-OPENEBS
+
+TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE
+    - ./stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE
+
 TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-STRIPE:
   image: harshshekhar15/gitlab-job:v2
   stage: OPENEBS-SETUP

--- a/stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE
+++ b/stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+pod() {
+
+## Installing OpenEBS using DOP on cluster2
+echo -e "\n************************ Installing OpenEBS *******************************************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE node'
+}
+
+node() {
+
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-install-openebs
+bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-cp-on-specific-node jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE/run_litmus_test.yml
+kubectl get pods -n litmus
+
+test_name=openebs-control-plane-test
+echo -e "\nTest Name: $test_name\n"
+
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-cp-on-specific-node jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-cp-on-specific-node jobphase:Completed
+fi 
+
+}
+
+if [ "$1" == "node" ];then
+  node
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE
+++ b/stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+pod() {
+
+## Installing OpenEBS using DOP on cluster2
+echo -e "\n************************ Installing OpenEBS *******************************************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE node'
+}
+
+node() {
+
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-install-openebs-cp-on-specific-node
+bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-dp-on-specific-node jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE/run_litmus_test.yml
+kubectl get pods -n litmus
+
+test_name=openebs-data-plane-test
+echo -e "\nTest Name: $test_name\n"
+
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-dp-on-specific-node jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-dp-on-specific-node jobphase:Completed
+fi 
+
+}
+
+if [ "$1" == "node" ];then
+  node
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE
+++ b/stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+pod() {
+
+## Installing OpenEBS using DOP on cluster2
+echo -e "\n************************ Installing OpenEBS *******************************************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE node'
+}
+
+node() {
+
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-re-install-openebs
+bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-limit-resource jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE/run_litmus_test.yml
+kubectl get pods -n litmus
+
+test_name=openebs-resource-limit-installation
+echo -e "\nTest Name: $test_name\n"
+
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-limit-resource jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-limit-resource jobphase:Completed
+fi 
+
+}
+
+if [ "$1" == "node" ];then
+  node
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-RE-INSTALL-OPENEBS
+++ b/stages/openebs-install/TCID-DIR-OP-RE-INSTALL-OPENEBS
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+pod() {
+
+## Installing OpenEBS using DOP on cluster2
+echo -e "\n************************ Installing OpenEBS *******************************************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-RE-INSTALL-OPENEBS node'
+}
+
+node() {
+
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-install-openebs-dp-on-specific-node
+bash utils/e2e-cr jobname:tcid-dir-op-re-install-openebs jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-RE-INSTALL-OPENEBS/run_litmus_test.yml
+kubectl get pods -n litmus
+
+test_name=openebs-reinstallation
+echo -e "\nTest Name: $test_name\n"
+
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config
+  bash utils/e2e-cr jobname:tcid-dir-op-re-install-openebs jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-re-install-openebs jobphase:Completed
+fi 
+
+}
+
+if [ "$1" == "node" ];then
+  node
+else
+  pod
+fi


### PR DESCRIPTION
Signed-off-by: Harsh Shekhar <harshshekhar15@gmail.com>

This PR intends to add the following openebs install tests to `oep-release` branch -
- TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE
- TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE
- TCID-DIR-OP-RE-INSTALL-OPENEBS
- TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE