### PR TITLE
Comment out the cstor-app-kill job from gitlab-ci yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -311,11 +311,11 @@ TCID-JIVA-REPLICA-NODE-AFFINITY:
     - chmod 755 ./stages/chaos/Jiva-Replica-Node-Affinity/rep-node-affinity
     - ./stages/chaos/Jiva-Replica-Node-Affinity/rep-node-affinity
 
-TCID-CSTOR-BUSYBOX-APP-KILL:
-  extends: .chaos_test_template
-  script:
-    - chmod 755 ./stages/chaos/cstor-App-pod-kill/app-kill
-    - ./stages/chaos/cstor-App-pod-kill/app-kill
+# TCID-CSTOR-BUSYBOX-APP-KILL:
+#   extends: .chaos_test_template
+#   script:
+#     - chmod 755 ./stages/chaos/cstor-App-pod-kill/app-kill
+#     - ./stages/chaos/cstor-App-pod-kill/app-kill
 
 TCID-CSTOR-TARGET-KILL:
   extends: .chaos_test_template


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>
- Removing the cstor-target-kill job from gitlab-ci yaml