### PR TITLE
comment out the jiva-app-kill job from gitlab-ci yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,11 +275,11 @@ TCID-LOCALPV-HOSTPATH-CREATE:
   dependencies:
     - TCID-DIR-OP-INSTALL-OPENEBS
 
-TCID-JIVA-BUSYBOX-KILL:
-  extends: .chaos_test_template
-  script:
-    - chmod 755 ./stages/chaos/Jiva-App-kill/jiva-app-kill
-    - ./stages/chaos/Jiva-App-kill/jiva-app-kill
+# TCID-JIVA-BUSYBOX-KILL:
+#   extends: .chaos_test_template
+#   script:
+#     - chmod 755 ./stages/chaos/Jiva-App-kill/jiva-app-kill
+#     - ./stages/chaos/Jiva-App-kill/jiva-app-kill
 
 TCID-JIVA-MULTIPLE-REPLICAS-FAILURE:
   extends: .chaos_test_template


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>
- removing the jiva-app-kill job from gitlab-ci yaml