### PR TITLE
feat(cstor-pool): add cstorpool recommendation tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,6 +151,78 @@ TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-STRIPE:
     - chmod 755 ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-STRIPE
     - ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-STRIPE
 
+TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR
+    - ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR
+
+TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE
+    - ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE
+
+TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR
+    - ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR
+
+TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM
+    - ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM
+
+TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME
+    - ./stages/openebs-install/TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME
+
+TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ
+    - ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ
+
+TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ
+    - ./stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ
+
+TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME:
+  image: harshshekhar15/gitlab-job:v2
+  stage: OPENEBS-SETUP
+  dependencies:
+    - cluster-create
+  script:
+    - chmod 755 ./stages/openebs-install/TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME
+    - ./stages/openebs-install/TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME
+
 TCID-OPENEBS-POLICIES-CREATE:
   image: harshshekhar15/gitlab-job:v2
   stage: OPENEBS-SETUP

--- a/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR
+++ b/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+pod() {
+
+## Running "TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR"
+echo -e "\n*************** Running TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR ****************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR node '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
+}
+
+node() {
+
+CI_JOB_ID=$1
+GITHUB_TOKEN=$2
+CI_COMMIT_REF_NAME=$3
+
+job_id=$(echo $CI_JOB_ID)
+gittoken=$(echo "$GITHUB_TOKEN")
+current_time=$(date)
+branch_name=$CI_COMMIT_REF_NAME
+stage="OPENEBS-INSTALL"
+test_desc="Verify creation of mirror cstor pool cluster"
+job_name=TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR
+
+## E2E Test case plan link
+e2e_tc_plan_link=https://e2e.mayadata.io/docs/director/openebs-provisioning/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR
+echo -e "\nTC_E2E_PLAN_LINK: $e2e_tc_plan_link\n"
+
+# Use cluster2 kube config
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-install-openebs-limit-resource
+bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-create-mirror jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR/run_litmus_test.yml
+kubectl get pods -n litmus 
+
+test_name=create-cstor-pool-mirror
+
+echo -e "\nTest Name: $test_name\n"
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+echo -e "\nBranch: $branch_name\n"
+if [[ $branch_name == "oep-release" ]]; then
+  echo -e "\nUpdating $job_name test results\n"
+  python3 oep-e2e/utils/result_update.py --job_id "$job_id" --stage "$stage" --test_desc "$test_desc" --test_result "$testResult" --time_stamp "$current_time" --token "$gittoken" --test_name "$test_name" --job_name "$job_name" --platform "rancher"
+fi
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-create-mirror jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-create-mirror jobphase:Completed
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR
+++ b/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR
@@ -33,6 +33,10 @@ bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-create-mirror jobphas
 
 export KUBECONFIG=~/.kube/cluster3_config
 
+# Label node2 as data-plane node as it has disks attached
+echo -e "\nLabeling rancher-c3-worker2 as data-plane node as it has disks attached\n"
+kubectl label nodes rancher-c3-worker2 mayadata.io/data-plane=true
+
 kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR/run_litmus_test.yml
 kubectl get pods -n litmus 
 

--- a/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ
+++ b/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+pod() {
+
+## Running "TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ"
+echo -e "\n*************** Running TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ ****************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ node '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
+}
+
+node() {
+
+CI_JOB_ID=$1
+GITHUB_TOKEN=$2
+CI_COMMIT_REF_NAME=$3
+
+job_id=$(echo $CI_JOB_ID)
+gittoken=$(echo "$GITHUB_TOKEN")
+current_time=$(date)
+branch_name=$CI_COMMIT_REF_NAME
+stage="OPENEBS-INSTALL"
+test_desc="Verify creation of raidz cstor pool cluster"
+job_name=TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ
+
+## E2E Test case plan link
+e2e_tc_plan_link=https://e2e.mayadata.io/docs/director/openebs-provisioning/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ
+echo -e "\nTC_E2E_PLAN_LINK: $e2e_tc_plan_link\n"
+
+# Use cluster2 kube config
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-cstor-pool-recommend-list-raidz
+bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-create-raidz jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ/run_litmus_test.yml
+kubectl get pods -n litmus 
+
+test_name=create-cstor-pool-raidz
+
+echo -e "\nTest Name: $test_name\n"
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+echo -e "\nBranch: $branch_name\n"
+if [[ $branch_name == "oep-release" ]]; then
+  echo -e "\nUpdating $job_name test results\n"
+  python3 oep-e2e/utils/result_update.py --job_id "$job_id" --stage "$stage" --test_desc "$test_desc" --test_result "$testResult" --time_stamp "$current_time" --token "$gittoken" --test_name "$test_name" --job_name "$job_name" --platform "rancher"
+fi
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-create-raidz jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-create-raidz jobphase:Completed
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR
+++ b/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+pod() {
+
+## Running "TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR"
+echo -e "\n*************** Running TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR ****************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR node '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
+}
+
+node() {
+
+CI_JOB_ID=$1
+GITHUB_TOKEN=$2
+CI_COMMIT_REF_NAME=$3
+
+job_id=$(echo $CI_JOB_ID)
+gittoken=$(echo "$GITHUB_TOKEN")
+current_time=$(date)
+branch_name=$CI_COMMIT_REF_NAME
+stage="OPENEBS-INSTALL"
+test_desc="Verify List of Mirror Recommendations"
+job_name=TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR
+
+## E2E Test case plan link
+e2e_tc_plan_link=https://e2e.mayadata.io/docs/director/openebs-provisioning/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR
+echo -e "\nTC_E2E_PLAN_LINK: $e2e_tc_plan_link\n"
+
+# Use cluster2 kube config
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-cstor-pool-recommend-list-stripe
+bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-mirror jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR/run_litmus_test.yml
+kubectl get pods -n litmus 
+
+test_name=list-recommendation-mirror
+
+echo -e "\nTest Name: $test_name\n"
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+echo -e "\nBranch: $branch_name\n"
+if [[ $branch_name == "oep-release" ]]; then
+  echo -e "\nUpdating $job_name test results\n"
+  python3 oep-e2e/utils/result_update.py --job_id "$job_id" --stage "$stage" --test_desc "$test_desc" --test_result "$testResult" --time_stamp "$current_time" --token "$gittoken" --test_name "$test_name" --job_name "$job_name" --platform "rancher"
+fi
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-mirror jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-mirror jobphase:Completed
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM
+++ b/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+pod() {
+
+## Running "TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM"
+echo -e "\n*************** Running TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM ****************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM node '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
+}
+
+node() {
+
+CI_JOB_ID=$1
+GITHUB_TOKEN=$2
+CI_COMMIT_REF_NAME=$3
+
+job_id=$(echo $CI_JOB_ID)
+gittoken=$(echo "$GITHUB_TOKEN")
+current_time=$(date)
+branch_name=$CI_COMMIT_REF_NAME
+stage="OPENEBS-INSTALL"
+test_desc="List Verification Without NDM"
+job_name=TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM
+
+## E2E Test case plan link
+e2e_tc_plan_link=https://e2e.mayadata.io/docs/director/openebs-provisioning/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM
+echo -e "\nTC_E2E_PLAN_LINK: $e2e_tc_plan_link\n"
+
+# Use cluster2 kube config
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-cstor-pool-recommend-list-mirror
+bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-no-ndm jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM/run_litmus_test.yml
+kubectl get pods -n litmus 
+
+test_name=list-recommendations-with-no-ndm
+
+echo -e "\nTest Name: $test_name\n"
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+echo -e "\nBranch: $branch_name\n"
+if [[ $branch_name == "oep-release" ]]; then
+  echo -e "\nUpdating $job_name test results\n"
+  python3 oep-e2e/utils/result_update.py --job_id "$job_id" --stage "$stage" --test_desc "$test_desc" --test_result "$testResult" --time_stamp "$current_time" --token "$gittoken" --test_name "$test_name" --job_name "$job_name" --platform "rancher"
+fi
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-no-ndm jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-no-ndm jobphase:Completed
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ
+++ b/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+pod() {
+
+## Running "TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ"
+echo -e "\n*************** Running TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ ****************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ node '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
+}
+
+node() {
+
+CI_JOB_ID=$1
+GITHUB_TOKEN=$2
+CI_COMMIT_REF_NAME=$3
+
+job_id=$(echo $CI_JOB_ID)
+gittoken=$(echo "$GITHUB_TOKEN")
+current_time=$(date)
+branch_name=$CI_COMMIT_REF_NAME
+stage="OPENEBS-INSTALL"
+test_desc="Verify List of raidz Recommendations"
+job_name=TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ
+
+## E2E Test case plan link
+e2e_tc_plan_link=https://e2e.mayadata.io/docs/director/openebs-provisioning/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ
+echo -e "\nTC_E2E_PLAN_LINK: $e2e_tc_plan_link\n"
+
+# Use cluster2 kube config
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-delete-cspc-with-no-volume
+bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-raidz jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ/run_litmus_test.yml
+kubectl get pods -n litmus 
+
+test_name=list-recommendations-raidz
+
+echo -e "\nTest Name: $test_name\n"
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+echo -e "\nBranch: $branch_name\n"
+if [[ $branch_name == "oep-release" ]]; then
+  echo -e "\nUpdating $job_name test results\n"
+  python3 oep-e2e/utils/result_update.py --job_id "$job_id" --stage "$stage" --test_desc "$test_desc" --test_result "$testResult" --time_stamp "$current_time" --token "$gittoken" --test_name "$test_name" --job_name "$job_name" --platform "rancher"
+fi
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-raidz jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-raidz jobphase:Completed
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE
+++ b/stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+pod() {
+
+## Running "TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE"
+echo -e "\n*************** Running TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE ****************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE node '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
+}
+
+node() {
+
+CI_JOB_ID=$1
+GITHUB_TOKEN=$2
+CI_COMMIT_REF_NAME=$3
+
+job_id=$(echo $CI_JOB_ID)
+gittoken=$(echo "$GITHUB_TOKEN")
+current_time=$(date)
+branch_name=$CI_COMMIT_REF_NAME
+stage="OPENEBS-INSTALL"
+test_desc="Verify List of Stripe Recommendations"
+job_name=TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE
+
+## E2E Test case plan link
+e2e_tc_plan_link=https://e2e.mayadata.io/docs/director/openebs-provisioning/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE
+echo -e "\nTC_E2E_PLAN_LINK: $e2e_tc_plan_link\n"
+
+# Use cluster2 kube config
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-cstor-pool-recommend-create-mirror
+bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-stripe jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE/run_litmus_test.yml
+kubectl get pods -n litmus 
+
+test_name=list-recommendations-stripe
+
+echo -e "\nTest Name: $test_name\n"
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+echo -e "\nBranch: $branch_name\n"
+if [[ $branch_name == "oep-release" ]]; then
+  echo -e "\nUpdating $job_name test results\n"
+  python3 oep-e2e/utils/result_update.py --job_id "$job_id" --stage "$stage" --test_desc "$test_desc" --test_result "$testResult" --time_stamp "$current_time" --token "$gittoken" --test_name "$test_name" --job_name "$job_name" --platform "rancher"
+fi
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-stripe jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-cstor-pool-recommend-list-stripe jobphase:Completed
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME
+++ b/stages/openebs-install/TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+pod() {
+
+## Running "TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME"
+echo -e "\n*************** Running TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME ****************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME node '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
+}
+
+node() {
+
+CI_JOB_ID=$1
+GITHUB_TOKEN=$2
+CI_COMMIT_REF_NAME=$3
+
+job_id=$(echo $CI_JOB_ID)
+gittoken=$(echo "$GITHUB_TOKEN")
+current_time=$(date)
+branch_name=$CI_COMMIT_REF_NAME
+stage="OPENEBS-INSTALL"
+test_desc="Verify deletion of CSPC with no volume"
+job_name=TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME
+
+## E2E Test case plan link
+e2e_tc_plan_link=https://e2e.mayadata.io/docs/director/openebs-provisioning/TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME
+echo -e "\nTC_E2E_PLAN_LINK: $e2e_tc_plan_link\n"
+
+# Use cluster2 kube config
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-cstor-pool-recommend-list-no-ndm
+bash utils/e2e-cr jobname:tcid-dir-op-delete-cspc-with-no-volume jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME/run_litmus_test.yml
+kubectl get pods -n litmus 
+
+test_name=delete-cspc-pool
+
+echo -e "\nTest Name: $test_name\n"
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+echo -e "\nBranch: $branch_name\n"
+if [[ $branch_name == "oep-release" ]]; then
+  echo -e "\nUpdating $job_name test results\n"
+  python3 oep-e2e/utils/result_update.py --job_id "$job_id" --stage "$stage" --test_desc "$test_desc" --test_result "$testResult" --time_stamp "$current_time" --token "$gittoken" --test_name "$test_name" --job_name "$job_name" --platform "rancher"
+fi
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-delete-cspc-with-no-volume jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-delete-cspc-with-no-volume jobphase:Completed
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi

--- a/stages/openebs-install/TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME
+++ b/stages/openebs-install/TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+pod() {
+
+## Running "TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME"
+echo -e "\n*************** Running TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME ****************\n"
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-rancher && bash stages/openebs-install/TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME node '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
+}
+
+node() {
+
+CI_JOB_ID=$1
+GITHUB_TOKEN=$2
+CI_COMMIT_REF_NAME=$3
+
+job_id=$(echo $CI_JOB_ID)
+gittoken=$(echo "$GITHUB_TOKEN")
+current_time=$(date)
+branch_name=$CI_COMMIT_REF_NAME
+stage="OPENEBS-INSTALL"
+test_desc="Verify deletion of SPC with no volume"
+job_name=TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME
+
+## E2E Test case plan link
+e2e_tc_plan_link=https://e2e.mayadata.io/docs/director/openebs-provisioning/TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME
+echo -e "\nTC_E2E_PLAN_LINK: $e2e_tc_plan_link\n"
+
+# Use cluster2 kube config
+export KUBECONFIG=~/.kube/cluster2_config
+
+bash utils/pooling jobname:tcid-dir-op-delete-cspc-with-no-volume
+bash utils/e2e-cr jobname:tcid-dir-op-delete-spc-with-no-volume jobphase:Running
+
+export KUBECONFIG=~/.kube/cluster3_config
+
+kubectl create -f oep-e2e/litmus/director/TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME/run_litmus_test.yml
+kubectl get pods -n litmus 
+
+test_name=delete-spc
+
+echo -e "\nTest Name: $test_name\n"
+litmus_pod=$(kubectl get po -n litmus | grep $test_name  | awk {'print $1'} | tail -n 1)
+echo $litmus_pod
+
+job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+
+while [[ "$job_status" != "Completed" ]]
+do 
+  job_status=$(kubectl get po  $litmus_pod -n litmus | awk {'print $3'} | tail -n 1)
+  sleep 6
+done
+
+kubectl logs -f $litmus_pod -n litmus
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+echo -e "\nTest Result: $testResult\n"
+
+echo -e "\nBranch: $branch_name\n"
+if [[ $branch_name == "oep-release" ]]; then
+  echo -e "\nUpdating $job_name test results\n"
+  python3 oep-e2e/utils/result_update.py --job_id "$job_id" --stage "$stage" --test_desc "$test_desc" --test_result "$testResult" --time_stamp "$current_time" --token "$gittoken" --test_name "$test_name" --job_name "$job_name" --platform "rancher"
+fi
+
+if [ "$testResult" != Pass ]
+then
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-delete-spc-with-no-volume jobphase:Completed
+  exit 1;
+else
+  export KUBECONFIG=~/.kube/cluster2_config 
+  bash utils/e2e-cr jobname:tcid-dir-op-delete-spc-with-no-volume jobphase:Completed
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi


### PR DESCRIPTION
The following PR intends to do add the following tests in `OPENEBS-SETUP` stage --
- TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-MIRROR
- TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-STRIPE
- TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-MIRROR
- TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-NO-NDM
- TCID-DIR-OP-DELETE-CSPC-WITH-NO-VOLUME
- TCID-DIR-OP-CSTOR-POOL-RECOMMEND-LIST-RAIDZ
- TCID-DIR-OP-CSTOR-POOL-RECOMMEND-CREATE-RAIDZ
- TCID-DIR-OP-DELETE-SPC-WITH-NO-VOLUME

The following pipeline ran successfully with the above changes - [Gitlab pipeline](https://gitlab.mayadata.io/oep/oep-e2e-rancher/pipelines/11244)