### PR TITLE
refact(script): add negative test case script for localpv-selected-blockdevice test

### DIFF
--- a/stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
+++ b/stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
@@ -26,21 +26,55 @@ bash utils/e2e-cr-new jobname:localpv-provisioning-selected-device jobphase:Runn
 cluster=cluster-2
 echo -e "\nCLUSTER_NAME: $cluster\n"
 
-echo "*******LocalPV-provisioning on selected device******"
+##########################
+#  positive test case    #
+##########################
 
-test_name=$(bash utils/generate_test_name testcase=localpv-selected-device metadata="")
+echo "*******LocalPV-provisioning on selected device positive test-case********"
+
+run_id="positive";test_name=$(bash utils/generate_test_name testcase=localpv-selected-device metadata=${run_id})
 echo $test_name
 
 cd e2e-tests
-cp experiments/functional/localpv/localpv-provisioning-selected-device/run_litmus_test.yml localpv_selected_device.yml
+cp experiments/functional/localpv/localpv-provisioning-selected-device/run_litmus_test.yml localpv_selected_device_positive.yml
 
 sed -i -e '/name: OPERATOR_NS/{n;s/.*/            value: openebs/g}' \
--e '/name: APP_NAMESPACE/{n;s/.*/            value: localpv-selected-device/g}' \
--e '/name: PVC/{n;s/.*/            value: localpv-selected-device-pvc/g}' localpv_selected_device.yml
+-e 's/app: localpv-selected-device/app: localpv-selected-device-positive/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: localpv-selected-device-positive/g}' \
+-e '/name: PVC/{n;s/.*/            value: localpv-selected-device-pvc/g}' \
+-e '/name: TEST_CASE_TYPE/{n;s/.*/            value: positive/g}' localpv_selected_device_positive.yml
 
-cat localpv_selected_device.yml
+cat localpv_selected_device_positive.yml
 
-bash ../utils/litmus_job_runner label='app:localpv-selected-device' job=localpv_selected_device.yml
+bash ../utils/litmus_job_runner label='app:localpv-selected-device-positive' job=localpv_selected_device_positive.yml
+cd ..
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:localpv-provisioning-selected-device $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+##########################
+#  negative test case    #
+##########################
+
+echo "*******LocalPV-provisioning on selected device negative test-case********"
+
+run_id="negative";test_name=$(bash utils/generate_test_name testcase=localpv-selected-device metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+cp experiments/functional/localpv/localpv-provisioning-selected-device/run_litmus_test.yml localpv_selected_device_negative.yml
+
+sed -i -e '/name: OPERATOR_NS/{n;s/.*/            value: openebs/g}' \
+-e 's/app: localpv-selected-device/app: localpv-selected-device-negative/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: localpv-selected-device-negative/g}' \
+-e '/name: PVC/{n;s/.*/            value: localpv-selected-device-pvc/g}' \
+-e '/name: TEST_CASE_TYPE/{n;s/.*/            value: negative/g}' localpv_selected_device_negative.yml
+
+cat localpv_selected_device_negative.yml
+
+bash ../utils/litmus_job_runner label='app:localpv-selected-device-negative' job=localpv_selected_device_negative.yml
 cd ..
 bash utils/dump_cluster_state;
 bash utils/event_updater jobname:localpv-provisioning-selected-device $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"

--- a/stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
+++ b/stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
@@ -44,6 +44,11 @@ sed -i -e '/name: OPERATOR_NS/{n;s/.*/            value: openebs/g}' \
 -e '/name: PVC/{n;s/.*/            value: localpv-selected-device-pvc/g}' \
 -e '/name: TEST_CASE_TYPE/{n;s/.*/            value: positive/g}' localpv_selected_device_positive.yml
 
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' localpv_selected_device_positive.yml
+
 cat localpv_selected_device_positive.yml
 
 bash ../utils/litmus_job_runner label='app:localpv-selected-device-positive' job=localpv_selected_device_positive.yml
@@ -72,6 +77,11 @@ sed -i -e '/name: OPERATOR_NS/{n;s/.*/            value: openebs/g}' \
 -e '/name: PVC/{n;s/.*/            value: localpv-selected-device-pvc/g}' \
 -e '/name: TEST_CASE_TYPE/{n;s/.*/            value: negative/g}' localpv_selected_device_negative.yml
 
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' localpv_selected_device_negative.yml
+
 cat localpv_selected_device_negative.yml
 
 bash ../utils/litmus_job_runner label='app:localpv-selected-device-negative' job=localpv_selected_device_negative.yml
@@ -80,11 +90,11 @@ bash utils/dump_cluster_state;
 bash utils/event_updater jobname:localpv-provisioning-selected-device $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 if [ "$?" != "0" ]; then
-bash utils/e2e-cr-new jobname:local-pv-device jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
+bash utils/e2e-cr-new jobname:localpv-provisioning-selected-device jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
 exit 1;
 fi
 
-bash utils/e2e-cr-new jobname:local-pv-device jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
+bash utils/e2e-cr-new jobname:localpv-provisioning-selected-device jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
 
 if [ "$?" != "0" ]; then
 exit 1;


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- This PR adds negative test case for localpv provisioning on selected device, where first we will provision the volume but the pvc will be remained in the pending state becuase of storage class constraints for block device tag. Then we will tag the bd's and verify the successful reconciliation and check if volume provisioning done successfully. 